### PR TITLE
Handled terminal NaN values

### DIFF
--- a/components/apps/barbell-plate-calculator/app.tsx
+++ b/components/apps/barbell-plate-calculator/app.tsx
@@ -5,8 +5,8 @@ import NumberCounter from './components/NumberCounter';
 import PlateVisualization from './components/PlateVisualization';
 import styles from './styles.module.css';
 
-const DEFAULT_TARGET_WEIGHT = '200.0';
-const DEFAULT_BAR_WEIGHT = '45.0';
+const DEFAULT_TARGET_WEIGHT = '200.0'; // lbs
+const DEFAULT_BAR_WEIGHT = '45.0'; // lbs
 
 const BarbellPlateCalculator = () => {
   const [targetWeight, setTargetWeight] = useLocalStorage('targetWeight', DEFAULT_TARGET_WEIGHT);

--- a/components/apps/barbell-plate-calculator/app.tsx
+++ b/components/apps/barbell-plate-calculator/app.tsx
@@ -9,8 +9,8 @@ const DEFAULT_TARGET_WEIGHT = '200.0';
 const DEFAULT_BAR_WEIGHT = '45.0';
 
 const BarbellPlateCalculator = () => {
-  const [targetWeight, setTargetWeight] = useLocalStorage('targetWeight', '200.0');
-  const [barWeight, setBarWeight] = useLocalStorage('barWeight', '45.0');
+  const [targetWeight, setTargetWeight] = useLocalStorage('targetWeight', DEFAULT_TARGET_WEIGHT);
+  const [barWeight, setBarWeight] = useLocalStorage('barWeight', DEFAULT_BAR_WEIGHT);
   const [view, setView] = useState<'visualization' | 'table'>('visualization');
 
   const { plates } = getPlates(parseFloat(targetWeight), parseFloat(barWeight));

--- a/components/apps/barbell-plate-calculator/app.tsx
+++ b/components/apps/barbell-plate-calculator/app.tsx
@@ -1,9 +1,12 @@
 import { RefreshIcon } from '@iconicicons/react';
 import { useLocalStorage } from 'usehooks-ts';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import NumberCounter from './components/NumberCounter';
 import PlateVisualization from './components/PlateVisualization';
 import styles from './styles.module.css';
+
+const DEFAULT_TARGET_WEIGHT = '200.0';
+const DEFAULT_BAR_WEIGHT = '45.0';
 
 const BarbellPlateCalculator = () => {
   const [targetWeight, setTargetWeight] = useLocalStorage('targetWeight', '200.0');
@@ -11,6 +14,16 @@ const BarbellPlateCalculator = () => {
   const [view, setView] = useState<'visualization' | 'table'>('visualization');
 
   const { plates } = getPlates(parseFloat(targetWeight), parseFloat(barWeight));
+
+  useEffect(() => {
+    if (targetWeight === "NaN") {
+      setTargetWeight(DEFAULT_TARGET_WEIGHT);
+    }
+
+    if (barWeight === "NaN") {
+      setBarWeight(DEFAULT_BAR_WEIGHT);
+    }
+  }, [targetWeight, barWeight]);
 
   return (
     <div className={styles.app}>

--- a/components/apps/barbell-plate-calculator/components/NumberCounter.tsx
+++ b/components/apps/barbell-plate-calculator/components/NumberCounter.tsx
@@ -33,7 +33,10 @@ const NumberCounter = ({ label, setValue, value }: Props) => {
             id={label}
             value={value}
             onChange={(e) => {
-              const newValue = parseInt(e.target.value, 10);
+              let newValue = parseInt(e.target.value, 10);
+              if (Number.isNaN(newValue)) {
+                newValue = 0;
+              }
               setValue(newValue.toString());
             }}
           />


### PR DESCRIPTION
If you delete all of the digits in the `NumberCounter` component (as you might do while holding the "backspace" key on mobile), the value would convert to `NaN` (understandable for a blank value parsed into an integer), prevent overwriting, and write itself to your local storage. This would then prevent you from using the app (forcing you to access the site in incognito mode) for a while. I've added some defensive code to clamp `NaN` values to `0`, which would allow the component to be modified.

Not handled in this PR, but worth investigating: there are peer dependencies issues that prevent `npm install` from running successfully without the `--force` parameter, and there are 

```
19 vulnerabilities (5 moderate, 11 high, 3 critical)
```

with the current package versions.